### PR TITLE
Fix typo 'trail' -> 'trial'

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,8 @@ usage() {
   echo "$ ./install.sh [options]"
   echo "options:"
   echo "-s,       for real-world deployment on a server"
-  echo "-l,       for trail purpose on a local VM"
+  echo "-l,       for trial purpose on a local VM"
+  echo "-h,       this message"
   exit 1;
 }
 

--- a/server/install.sh
+++ b/server/install.sh
@@ -2,8 +2,8 @@
 usage() {
   echo "$ ./install.sh [options]"
   echo "options:"
-  echo "-http,       for real-world deployment on a server"
-  echo "-https,       for trail purpose on a local VM"
+  echo "-s,       for real-world deployment on a server"
+  echo "-l,       for trial purpose on a local VM"
   exit 1;
 }
 


### PR DESCRIPTION
Noticed a typo when I was installing. Also fixed usage string in both scripts to be consistent.

Going to be using this system a lot next semester. Should be fun!

Cheers