### PR TITLE
Bind ./courses instead of ./Autolab/courses

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -26,5 +26,5 @@ web:
     - '80:80'
     - '443:443'
   volumes:
-    - ./Autolab/courses:/home/app/webapp/courses
+    - ./courses:/home/app/webapp/courses
     - ./ssl:/etc/nginx/ssl


### PR DESCRIPTION
It's safer to bind `./courses` instead of `./Autolab/courses`, because `./Autolab` will be deleted when reinstall.